### PR TITLE
Fix shell script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # hledger-sankey
-Script + html files to plot income vs expense money flows from hledger ledger
+Script + html files to plot income vs expense money flows from hledger ledger as Sankey diagram
 
 This is a proof of concept that I hacked in a hurry to see if this could be done and to compare different JavaScript implementations
-of Sankey graph plotters.
+of Sankey plotters.
 
 # Use it
 Run `./sankey.sh /path/to/your.ledger`, which will generate `sankey.csv` in the `html` subdirectory.

--- a/README.md
+++ b/README.md
@@ -29,3 +29,12 @@ Script makes a bunch of assumptions:
 - `incomestatement` report will be generated in cost basis (with `--cost` argument)
 
 If these assumptions do not hold for you, edit the script.
+
+# Examples
+I personally hink that amscharts and highcharts yield the best results. Here is rendering of the sample file
+
+## Amscharts
+![Amscharts](img/amscharts-sankey-diagram.png)
+
+## Highcharts
+![Highcharts](img/highcharts-sankey-diagram.png)

--- a/sankey.sh
+++ b/sankey.sh
@@ -7,9 +7,9 @@
 (
   echo "source,target,value"; 
   (
-     hledger -f "$1" is --cost -O csv -N --tree \
-     | sed -nre 's/["£$]//g; /expenses,/{s/^/income,/;p}; /expenses[^,]/{s/(.+):([^:]+),/\1,\1:\2,/;p}; /income[^,]/{s/(.+):([^:]+),/\1:\2,\1,/;p};'  \
-     | awk -vOFS=, -F, '$3 > 50 {print $1,$2,$3}' \
-     | sort -rn -t, -k3 
+    hledger -f "$1" balance -O csv -N -X USD --tree \
+    | sed -nre 's/["USD\-]//g; /expenses,/{s/^/income,/;p}; /expenses[^,]/{s/(.+):([^:]+),/\1,\1:\2,/;p}; /income[^,]/{s/(.+):([^    :]+),/\1:\2,\1,/;p};' \
+    | awk '/^expenses/{t=t$0"\n";next}1;END {print t}' \
+    | awk -vOFS=, -F, '$3 > 50 {print $1,$2,$3}'
   )
 ) > ./html/sankey.csv


### PR DESCRIPTION
https://github.com/simonmichael/hledger/issues/1566

There is this issue affecting hledger 1.21 that makes reporting using the `--tree` option and outputting to csv to not have the full account name and thus removing the ability to parse the info correctly for this repo.

I think this PR fixes the issue but may need further testing.